### PR TITLE
Remove Python 3.8 support (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -22,9 +21,7 @@ jobs:
           - "dj42" # LTS
           - "dj50"
         exclude:
-          # Python 3.8/3.9 is incompatible with Django 5.0+
-          - python-version: "3.8"
-            tox-env: "dj50"
+          # Python 3.9 is incompatible with Django 5.0+
           - python-version: "3.9"
             tox-env: "dj50"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v3.21.0
     hooks:
     -   id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Automated code metrics:
 
 * Free software: MIT license
 * Documentation for the Click command line library: https://click.palletsprojects.com/en/stable/
-* Compatible with Django 4.2 and 5.0 running on Python 3.8, 3.9, 3.10, 3.11, and 3.12 (note: 3.10+ required for Django 5.0).
+* Compatible with Django 4.2 and 5.0 running on Python 3.9, 3.10, 3.11, and 3.12 (note: 3.10+ required for Django 5.0).
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Depends on:
- https://github.com/django-commons/django-click/pull/49