### PR TITLE
Remove Python 3.9 support (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
         tox-env:
           - "dj42" # LTS
           - "dj50"
-        exclude:
-          # Python 3.9 is incompatible with Django 5.0+
-          - python-version: "3.9"
-            tox-env: "dj50"
 
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v3.21.0
     hooks:
     -   id: pyupgrade
-        args: ["--py39-plus"]
+        args: ["--py310-plus"]

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Automated code metrics:
 
 * Free software: MIT license
 * Documentation for the Click command line library: https://click.palletsprojects.com/en/stable/
-* Compatible with Django 4.2 and 5.0 running on Python 3.9, 3.10, 3.11, and 3.12 (note: 3.10+ required for Django 5.0).
+* Compatible with Django 4.2 and 5.0 running on Python 3.10, 3.11, and 3.12 (note: 3.10+ required for Django 5.0).
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Depends on:
- https://github.com/django-commons/django-click/pull/50