### PR TITLE
Update the upper bound for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install tox and coverage packages
         run: |
-          pip install tox tox-gh-actions 'coverage<5' coveralls
+          pip install tox tox-gh-actions 'coverage<8' coveralls
 
       - name: Run tox and coverage
         run: |

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 pytest
-coverage<5
+coverage<8
 pytest-django
 pytest-cov
 pytest-flake8


### PR DESCRIPTION
Local test run was generating tons of

> django-click/.tox/dj50/lib/python3.14/site-packages/coverage/parser.py:374: DeprecationWarning: co_lnotab is deprecated, use co_lines instead.

warning