### PR TITLE
Add trove classifiers for Django

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ PACKAGE_NAME = "django-click"
 DESCRIPTION = "Build Django management commands using the click CLI package."
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Adds trove classifiers for Django, so the support info can be seen on PyPI page and can be used to generate badges.