### PR TITLE
Remove redundant dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,13 +4,6 @@
 wheel
 check-manifest
 
-# Code linting
-flake8
-mccabe
-pep8
-pep8-naming
-pyflakes
-
 # Documentation
 Sphinx
 sphinx-autobuild

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,5 @@
 -r requirements-test.txt
 
-# Automation
-Fabric
-livereload
-
 # Packaging
 wheel
 check-manifest


### PR DESCRIPTION
Small cleaning before https://github.com/django-commons/django-click/pull/67 . Seperating these changes from the other PR to keep the reasoning visible in git history.

Removes redundant "automation" and "code linting" dependencies.